### PR TITLE
Handle exception on timestamp parsing from .run file

### DIFF
--- a/changelog.d/9.fixed.md
+++ b/changelog.d/9.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in which the watcher thread might crash due to an empty `.run` file


### PR DESCRIPTION
Under certain conditions, when the executor writes the timestamp in the `.run` file, the backend watcher might actually read an empty file, leading to a `ValueError` raised as the `''` string can't be parsed into an ISO-formated date.

Next, the watcher thread will stop working, leading to indefinite waiting from the parent process as the tasks will not be completed.

This PR fixes this issue by:

1) Wrapping the `_watcher` in a try/except block, allowing to continue working and logging raised exceptions.
2) Catching a `ValueError` when parsing the date.