### PR TITLE
Consider errors from htcondor scheduler

### DIFF
--- a/changelog.d/10.fixed.md
+++ b/changelog.d/10.fixed.md
@@ -1,0 +1,1 @@
+Fix a bug in which the scheduler submit call might fail and job will be lost

--- a/joblib_htcondor/backend.py
+++ b/joblib_htcondor/backend.py
@@ -920,6 +920,9 @@ class _HTCondorBackend(ParallelBackendBase):
                                 # Put the job back in the queue
                                 self._queued_jobs_list.appendleft(to_submit)
 
+                                # Delete the pickle file
+                                to_submit.pickle_fname.unlink()
+
                                 # Wait a bit before trying again
                                 time.sleep(1)
                                 continue

--- a/joblib_htcondor/tests/test_backend.py
+++ b/joblib_htcondor/tests/test_backend.py
@@ -37,7 +37,7 @@ def compare_backends(a, b) -> bool:
 
 def test_pickle() -> None:
     """Test pickling of the backend."""
-    backend = _HTCondorBackend()
+    backend = _HTCondorBackend(request_cpus=1, request_memory="2GB")
     pickled_backend = pickle.loads(pickle.dumps(backend))
     assert compare_backends(pickled_backend, backend)
 


### PR DESCRIPTION
Under certain cirscunstances, this error might appear:

```
2024-10-28 01:02:39,583 - joblib_htcondor.backend - ERROR - Traceback (most recent call last):
  File "/home/fraimondo/dev/tbox/joblib-htcondor/joblib_htcondor/backend.py", line 907, in _watcher
    self._client.submit(
  File "/home/fraimondo/miniconda3/envs/julearn/lib/python3.12/site-packages/htcondor2/_schedd.py", line 454, in submit
    return _schedd_submit(self._addr, real._handle, count, spool)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: Failed to connect to schedd.
```

Currently, if this happens, then the job is not submitted but also removed from the backend queue, resulting in joblib never finishing as at least one future will not have a result.

This PR fixes this issue by:

1) Surrounding the `_client.submit` call in a try/except block.
2) Re-adding the job back to the backend queue if this call fails.
3) Deleting the pickled job file/
4) Showing an error in the log.
5) Waiting 1 second before continuing, to avoid spamming the scheduler that might be overwhelmed.