### PR TITLE
Use HTCondorException instead of RuntimeError

### DIFF
--- a/changelog.d/14.fixed.md
+++ b/changelog.d/14.fixed.md
@@ -1,1 +1,1 @@
-Fixed a bug in which an HTCondorException was not catched due to a change in HTCondor API
+Fixed a bug in which an HTCondorException was not caught due to a change in HTCondor API

--- a/changelog.d/14.fixed.md
+++ b/changelog.d/14.fixed.md
@@ -1,0 +1,1 @@
+Fixed a bug in which an HTCondorException was not catched due to a change in HTCondor API

--- a/joblib_htcondor/backend.py
+++ b/joblib_htcondor/backend.py
@@ -455,7 +455,7 @@ class _HTCondorBackend(ParallelBackendBase):
             # Try to create a scheduler client using local daemon
             try:
                 schedd = htcondor2.Schedd()
-            except RuntimeError as err:
+            except htcondor2.HTCondorException as err:
                 # Initiate collector client
                 collector = htcondor2.Collector(self._pool)
                 # Query for scheduler ads


### PR DESCRIPTION
Htcondor python bindings changed and now if a local Schedd is unavailable, it will raise a `HTCondorException`